### PR TITLE
Switched to our own standalone-install.yaml

### DIFF
--- a/00-locals.tf
+++ b/00-locals.tf
@@ -49,7 +49,7 @@ locals {
         ]
       },
       extraManifests = [
-        "https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml",
+        "https://raw.githubusercontent.com/isovalent/terraform-aws-talos/main/standalone-install.yaml",
         "https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml"
       ],
       allowSchedulingOnControlPlanes = var.allow_workload_on_cp_nodes

--- a/standalone-install.yaml
+++ b/standalone-install.yaml
@@ -4,9 +4,9 @@ metadata:
   labels:
     app.kubernetes.io/instance: kubelet-serving-cert-approver
     app.kubernetes.io/name: kubelet-serving-cert-approver
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: kubelet-serving-cert-approver
 ---
 apiVersion: v1


### PR DESCRIPTION
Switched to our own Kubelet cert approver deployment (standalone-install.yaml) which is running in hostNetwork to ensure it doesn't relay on Cilium to be started first.

This PR should fix #34 