### PR TITLE
test: use the first five chars of md5sum of unique workflow run ident…

### DIFF
--- a/.github/workflows/conformance-13-pr.yml
+++ b/.github/workflows/conformance-13-pr.yml
@@ -55,7 +55,7 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr ${{ github.run_number }} \
+            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/.github/workflows/conformance-13.yml
+++ b/.github/workflows/conformance-13.yml
@@ -132,7 +132,7 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr ${{ github.run_number }} \
+            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/.github/workflows/conformance-pr.yml
+++ b/.github/workflows/conformance-pr.yml
@@ -52,7 +52,7 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr ${{ github.run_number }} \
+            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -119,7 +119,7 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr ${{ github.run_number }} \
+            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/test/conformance/create-ci-env.sh
+++ b/test/conformance/create-ci-env.sh
@@ -80,9 +80,7 @@ if [ -z "$kube_proxy" ] && [ -z "$talos_version" ] && [ -z "$owner" ]; then
     usage
 fi
 
-
-pr_name=$(head -c 15 <<< ${pr_name})
-num=$(head -c 3 <<< ${RANDOM})
+id=$(md5sum <<< ${pr_name} | head -c 5)
 
 disable_kube_proxy=false
 if [ ${kube_proxy} == "false" ]; then
@@ -90,7 +88,7 @@ if [ ${kube_proxy} == "false" ]; then
 fi
 
 cat > env.tfvars << EOF
-cluster_name = "talos-e2e-${pr_name}-${num}"
+cluster_name = "talos-e2e-${id}"
 region = "us-east-2"
 owner = "${owner}"
 talos_version = "${talos_version}"


### PR DESCRIPTION
The tuple (repo, run_id, run_attempt) identifies a workflow run, however this is too long for the terraform talos name. So we use this to generate a 5-digit hash instead of using random 3 digit ids which are prone to collisions.

