### PR TITLE
add wait for lb step to prevent flakes due to apiserver not being ready.

### DIFF
--- a/.github/workflows/conformance-13-pr.yml
+++ b/.github/workflows/conformance-13-pr.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Install Cilium
         run: |
           cd test/conformance
+          timeout 120 bash -c "until curl http://$(terraform output -raw elb_dns_name):443 -k -m 3; do sleep 1 && echo 'waiting for apiserver'; done"
+          if [ $? -ne 0 ]; then
+            echo "API Server LB failed to become available."
+            exit 1
+          fi
           export $(make print-kubeconfig)
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"

--- a/.github/workflows/conformance-13.yml
+++ b/.github/workflows/conformance-13.yml
@@ -146,6 +146,11 @@ jobs:
       - name: Install Cilium
         run: |
           cd test/conformance
+          timeout 120 bash -c "until curl http://$(terraform output -raw elb_dns_name):443 -k -m 3; do sleep 1 && echo 'waiting for apiserver'; done"
+          if [ $? -ne 0 ]; then
+            echo "API Server LB failed to become available."
+            exit 1
+          fi
           export $(make print-kubeconfig)
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"

--- a/.github/workflows/conformance-pr.yml
+++ b/.github/workflows/conformance-pr.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Install Cilium
         run: |
           cd test/conformance
+          # Wait until the apiserver LB is ready
+          timeout 120 bash -c "until curl http://$(terraform output -raw elb_dns_name):443 -k -m 3; do sleep 1 && echo 'waiting for apiserver'; done"
+          if [ $? -ne 0 ]; then
+            echo "API Server LB failed to become available."
+            exit 1
+          fi
           export $(make print-kubeconfig)
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -133,6 +133,11 @@ jobs:
       - name: Install Cilium
         run: |
           cd test/conformance
+          timeout 120 bash -c "until curl http://$(terraform output -raw elb_dns_name):443 -k -m 3; do sleep 1 && echo 'waiting for apiserver'; done"
+          if [ $? -ne 0 ]; then
+            echo "API Server LB failed to become available."
+            exit 1
+          fi
           export $(make print-kubeconfig)
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"


### PR DESCRIPTION
Should fix flakes related LB not being ready before doing cilium install:

```
error: failed to create secret Post "https://talos-e2e-31-179-k8s-api-1790045543.us-east-2.elb.amazonaws.com/api/v1/namespaces/kube-system/secrets?fieldManager=kubectl-create&fieldValidation=Strict": EOF
Error: Process completed with exit code 1.
```
Example: https://github.com/isovalent/terraform-aws-talos/actions/runs/8781389133/job/24093307100

Simply curl the LB for 2 minutes following creating the cluster.