### PR TITLE
Fixed Cilium(-CLI) dependency versioning

### DIFF
--- a/.github/workflows/conformance-13-pr.yml
+++ b/.github/workflows/conformance-13-pr.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         cilium:
           # renovate: datasource=github-releases depName=cilium/cilium
-          - 'v1.13.10'
+          - '1.13.10'
         talos:
           # renovate: datasource=github-releases depName=siderolabs/talos
           - 'v1.6.5'
@@ -78,7 +78,7 @@ jobs:
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
           kubectl create -n kube-system -f ipmasq-config.yaml
-          cilium-cli install --version="${{ matrix.cilium }}" \
+          cilium-cli install --version="v${{ matrix.cilium }}" \
             --values=values.yaml \
             --set ipv4.enabled=${{ matrix.config.ipv4 }} \
             --set ipv6.enabled=${{ matrix.config.ipv6 }} \

--- a/.github/workflows/conformance-13.yml
+++ b/.github/workflows/conformance-13.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         cilium:
           # renovate: datasource=github-releases depName=cilium/cilium
-          - 'v1.13.10'
+          - '1.13.10'
         talos:
           # renovate: datasource=github-releases depName=siderolabs/talos
           - 'v1.6.5'
@@ -155,7 +155,7 @@ jobs:
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
           kubectl create -n kube-system -f ipmasq-config.yaml
-          cilium-cli install --version="${{ matrix.cilium }}" \
+          cilium-cli install --version="v${{ matrix.cilium }}" \
             --values=values.yaml \
             --set ipv4.enabled=${{ matrix.config.ipv4 }} \
             --set ipv6.enabled=${{ matrix.config.ipv6 }} \

--- a/.github/workflows/conformance-pr.yml
+++ b/.github/workflows/conformance-pr.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         cilium:
           # renovate: datasource=github-releases depName=cilium/cilium
-          - 'v1.15.1'
+          - '1.15.1'
           # renovate: datasource=github-releases depName=cilium/cilium
-          - 'v1.14.5'
+          - '1.14.5'
         talos:
           # renovate: datasource=github-releases depName=siderolabs/talos
           - 'v1.6.5'
@@ -76,7 +76,7 @@ jobs:
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
           kubectl create -n kube-system -f ipmasq-config.yaml
-          cilium-cli install --version="${{ matrix.cilium }}" \
+          cilium-cli install --version="v${{ matrix.cilium }}" \
             --values=values.yaml \
             --set ipv4.enabled=${{ matrix.config.ipv4 }} \
             --set ipv6.enabled=${{ matrix.config.ipv6 }} \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         cilium:
           # renovate: datasource=github-releases depName=cilium/cilium
-          - 'v1.15.1'
+          - '1.15.1'
           # renovate: datasource=github-releases depName=cilium/cilium
-          - 'v1.14.5'
+          - '1.14.5'
         talos:
           # renovate: datasource=github-releases depName=siderolabs/talos
           - 'v1.6.5'
@@ -142,7 +142,7 @@ jobs:
           kubectl create -n kube-system secret generic cilium-ipsec-keys \
             --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
           kubectl create -n kube-system -f ipmasq-config.yaml
-          cilium-cli install --version="${{ matrix.cilium }}" \
+          cilium-cli install --version="v${{ matrix.cilium }}" \
             --values=values.yaml \
             --set ipv4.enabled=${{ matrix.config.ipv4 }} \
             --set ipv6.enabled=${{ matrix.config.ipv6 }} \


### PR DESCRIPTION
[Cilium](https://github.com/cilium/cilium/releases) doesn't prepend a `v`, while [Cilium-CLI](https://github.com/cilium/cilium-cli/releases) does. Let's unify this so renovate is for sure able to find the regarding releases via `"datasourceTemplate": "github-releases",`.