### PR TITLE
.github: conformance: use matrix.config.name.

### DIFF
--- a/.github/workflows/conformance-13-pr.yml
+++ b/.github/workflows/conformance-13-pr.yml
@@ -55,7 +55,10 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
+            --test ${{ matrix.config.name }} \
+            --run-id ${{ github.run_id }} \
+            --run-no ${{ github.run_number }} \
+            --cilium-version ${{ matrix.cilium }} \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/.github/workflows/conformance-13.yml
+++ b/.github/workflows/conformance-13.yml
@@ -132,7 +132,10 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
+            --test ${{ matrix.config.name }} \
+            --run-id ${{ github.run_id }} \
+            --run-no ${{ github.run_number }} \
+            --cilium-version ${{ matrix.cilium }} \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/.github/workflows/conformance-pr.yml
+++ b/.github/workflows/conformance-pr.yml
@@ -52,7 +52,10 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.job }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
+            --test ${{ matrix.config.name }} \
+            --run-id ${{ github.run_id }} \
+            --run-no ${{ github.run_number }} \
+            --cilium-version ${{ matrix.cilium }} \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -119,7 +119,10 @@ jobs:
           ./create-ci-env.sh \
             --kube-proxy ${{ matrix.config.kube-proxy}} \
             --talos-version ${{ matrix.talos }} \
-            --pr "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_number}}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.cilium }}-${{ matrix.talos }}" \
+            --test ${{ matrix.config.name }} \
+            --run-id ${{ github.run_id }} \
+            --run-no ${{ github.run_number }} \
+            --cilium-version ${{ matrix.cilium }} \
             --owner "isovalent/terraform-aws-talos"
           make apply
       - name: Install Cilium CLI

--- a/test/conformance/00-locals.tf
+++ b/test/conformance/00-locals.tf
@@ -4,7 +4,11 @@ locals {
   tags = merge(
     tomap({
       "expiry" : local.expiry,
-      "owner" : var.owner
+      "owner" : var.owner,
+      "run_id" : "https://github.com/isovalent/terraform-aws-talos/actions/runs/${var.run_id}",
+      "run_number" : var.run_number,
+      "test_name" : var.test_name,
+      "cilium_version" : var.cilium_version,
     }),
     var.tags
   )

--- a/test/conformance/00-variables.tf
+++ b/test/conformance/00-variables.tf
@@ -69,3 +69,19 @@ variable "pod_cidr" {
 variable "disable_kube_proxy" {
   type = bool
 }
+
+variable "run_id" {
+  type = string
+}
+
+variable "run_number" {
+  type = string
+}
+
+variable "test_name" {
+  type = string
+}
+
+variable "cilium_version" {
+  type = string
+}


### PR DESCRIPTION
Old VPCs/LBs are not being cleaned up, and I can't figure out what jobs they're failing on.  So this refactors the create test env script a bit to pass run id/number as well as cilium_version and test_name separately, then we can write these to the test infra tags to help us figure out what cloud resources belong to what test run.

As well, the naming is still failing so I'm going to just do `md5sum($run_id-$run_number-$random)` to (hopefully) make it extremely unlikely of a collision.