### PR TITLE
conformance: Added bpf-hostlegacyrouting option

### DIFF
--- a/.github/workflows/conformance-pr.yml
+++ b/.github/workflows/conformance-pr.yml
@@ -29,6 +29,7 @@ jobs:
             kube-proxy-replacement: "true"
             socketlb: false
             bpf-masquerade: true
+            bpf-hostlegacyrouting: true
             ipam-mode: 'kubernetes'
             ipv4: true
             ipv6: false
@@ -88,6 +89,7 @@ jobs:
             --set ipv4.enabled=${{ matrix.config.ipv4 }} \
             --set ipv6.enabled=${{ matrix.config.ipv6 }} \
             --set bpf.masquerade=${{ matrix.config.bpf-masquerade }} \
+            --set bpf.hostLegacyRouting=${{ matrix.config.bpf-hostlegacyrouting }} \
             --set kubeProxyReplacement=${{ matrix.config.kube-proxy-replacement }} \
             --set socketLB.enabled=${{ matrix.config.socketlb }} \
             --set ipam.mode=${{ matrix.config.ipam-mode }} \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -35,6 +35,7 @@ jobs:
             kube-proxy-replacement: "true"
             socketlb: false
             bpf-masquerade: true
+            bpf-hostlegacyrouting: true
             ipam-mode: 'kubernetes'
             ipv4: true
             ipv6: false
@@ -49,6 +50,7 @@ jobs:
             kube-proxy-replacement: "true"
             socketlb: false
             bpf-masquerade: true
+            bpf-hostlegacyrouting: true
             ipam-mode: 'kubernetes'
             ipv4: true
             ipv6: false
@@ -63,6 +65,7 @@ jobs:
             kube-proxy-replacement: "false"
             socketlb: true
             bpf-masquerade: false
+            bpf-hostlegacyrouting: true
             ipam-mode: 'kubernetes'
             ipv4: true
             ipv6: false
@@ -77,6 +80,7 @@ jobs:
             kube-proxy-replacement: "false"
             socketlb: true
             bpf-masquerade: true
+            bpf-hostlegacyrouting: true
             ipam-mode: 'kubernetes'
             ipv4: true
             ipv6: false
@@ -90,6 +94,7 @@ jobs:
             kube-proxy-replacement: "true"
             socketlb: false
             bpf-masquerade: true
+            bpf-hostlegacyrouting: true
             ipam-mode: 'cluster-pool'
             ipv4: true
             ipv6: false
@@ -104,6 +109,7 @@ jobs:
             kube-proxy-replacement: "true"
             socketlb: false
             bpf-masquerade: true
+            bpf-hostlegacyrouting: true
             ipam-mode: 'kubernetes'
             ipv4: true
             ipv6: false
@@ -163,6 +169,7 @@ jobs:
             --set ipv4.enabled=${{ matrix.config.ipv4 }} \
             --set ipv6.enabled=${{ matrix.config.ipv6 }} \
             --set bpf.masquerade=${{ matrix.config.bpf-masquerade }} \
+            --set bpf.hostLegacyRouting=${{ matrix.config.bpf-hostlegacyrouting }} \
             --set kubeProxyReplacement=${{ matrix.config.kube-proxy-replacement }} \
             --set socketLB.enabled=${{ matrix.config.socketlb }} \
             --set ipam.mode=${{ matrix.config.ipam-mode }} \


### PR DESCRIPTION
Added a configurable bpf-hostlegacyrouting option to the conformance tests as Cilium 1.16.5+ introduced a breaking change for Talos 'forwardKubeDNSToHost'. See https://github.com/cilium/cilium/pull/35098 for more details.

I've explicitly set `bpf-hostlegacyrouting: true` for all test cases. For the KPR ones to fix the issue mentioned above, and for the others as it's disabled anyway in their case (because of enabled IPsec and KPR being disabled). Please look at the relevant code [here](https://github.com/cilium/cilium/blob/ad6882773c5f89feda9c295276707f01de269296/daemon/cmd/kube_proxy_replacement.go#L368-L390).