### PR TITLE
Updated tolerations for standalone-install.yaml

### DIFF
--- a/standalone-install.yaml
+++ b/standalone-install.yaml
@@ -209,3 +209,6 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists


### PR DESCRIPTION
Added `node.cloudprovider.kubernetes.io/uninitialized` toleration for the kubelet serving cert approver.