### PR TITLE
Breaking change: Change the `0.0.0.0/0` default for the allowed source IP CIDRs (of the SGs)

### DIFF
--- a/00-variables.tf
+++ b/00-variables.tf
@@ -154,14 +154,20 @@ variable "vpc_cidr" {
   type        = string
 }
 
+variable "external_source_cidrs" {
+  default     = []
+  description = "Specify the external source CIDRs (use /32 for specific IP addresses) allowed for inbound traffic. It can be used to override var.talos_api_allowed_cidr and var.kubernetes_api_allowed_cidr at the same time."
+  type        = list(string)
+}
+
 variable "talos_api_allowed_cidr" {
-  default     = "0.0.0.0/0"
+  default     = ""
   description = "The CIDR from which to allow to access the Talos API"
   type        = string
 }
 
 variable "kubernetes_api_allowed_cidr" {
-  default     = "0.0.0.0/0"
+  default     = ""
   description = "The CIDR from which to allow to access the Kubernetes API"
   type        = string
 }

--- a/02-infra.tf
+++ b/02-infra.tf
@@ -13,13 +13,14 @@ module "cluster_sg" {
     },
   ]
 
+  ingress_cidr_blocks = length(var.external_source_cidrs) != 0 ? var.external_source_cidrs : [var.talos_api_allowed_cidr]
+
   ingress_with_cidr_blocks = [
     {
       from_port   = 50000
       to_port     = 50000
       protocol    = "tcp"
-      cidr_blocks = var.talos_api_allowed_cidr
-      description = "Talos API Access"
+      description = "Talos API"
     },
   ]
 
@@ -38,8 +39,8 @@ module "kubernetes_api_sg" {
   name                = "${var.cluster_name}-k8s-api"
   description         = "Allow access to the Kubernetes API"
   vpc_id              = var.vpc_id
-  ingress_cidr_blocks = [var.kubernetes_api_allowed_cidr]
   tags                = var.tags
+  ingress_cidr_blocks = length(var.external_source_cidrs) != 0 ? var.external_source_cidrs : [var.kubernetes_api_allowed_cidr]
 }
 
 module "elb_k8s_elb" {

--- a/README.md
+++ b/README.md
@@ -26,15 +26,18 @@ module "talos" {
   source = "git::https://github.com/isovalent/terraform-aws-talos?ref=<RELEASE_TAG>"
 
   // Supported Talos versions (and therefore K8s versions) can be found here: https://github.com/siderolabs/talos/releases
-  talos_version      = "v1.10.4"
-  kubernetes_version = "1.33.1"
-  cluster_name       = "talos-cute"
-  region             = "eu-west-1"
-  tags               = local.tags
+  talos_version         = "v1.10.4"
+  kubernetes_version    = "1.33.1"
+  cluster_name          = "talos-cute"
+  region                = "eu-west-1"
+  tags                  = local.tags
   // VPC needs to be created in advance via https://github.com/isovalent/terraform-aws-vpc
-  vpc_id             = module.vpc.id
-  pod_cidr           = "100.64.0.0/14"
-  service_cidr       = "100.68.0.0/16"
+  vpc_id                = module.vpc.id
+  pod_cidr              = "100.64.0.0/14"
+  service_cidr          = "100.68.0.0/16"
+  # Configure the allowed source CIDR ranges globally via var.external_source_cidrs.
+  # Alternatively, via var.talos_api_allowed_cidr or var.kubernetes_api_allowed_cidr.
+  external_source_cidrs = "A.B.C.D/E"
 }
 ```
 
@@ -110,16 +113,17 @@ module "talos" {
 | <a name="input_disable_kube_proxy"></a> [disable\_kube\_proxy](#input\_disable\_kube\_proxy) | Whether to deploy Kube-Proxy or not. By default, KP shouldn't be deployed. | `bool` | `true` | no |
 | <a name="input_enable_external_cloud_provider"></a> [enable\_external\_cloud\_provider](#input\_enable\_external\_cloud\_provider) | Whether to enable or disable externalCloudProvider support. See https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/. | `bool` | `false` | no |
 | <a name="input_external_cloud_provider_manifest"></a> [external\_cloud\_provider\_manifest](#input\_external\_cloud\_provider\_manifest) | externalCloudProvider manifest to be applied if var.enable\_external\_cloud\_provider is enabled. If you want to deploy it manually (e.g., via Helm chart), enable var.enable\_external\_cloud\_provider but set this value to an empty string (""). See https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/. | `string` | `"https://raw.githubusercontent.com/isovalent/terraform-aws-talos/main/manifests/aws-cloud-controller.yaml"` | no |
+| <a name="input_external_source_cidrs"></a> [external\_source\_cidrs](#input\_external\_source\_cidrs) | Specify the external source CIDRs (use /32 for specific IP addresses) allowed for inbound traffic. It can be used to override var.talos\_api\_allowed\_cidr and var.kubernetes\_api\_allowed\_cidr at the same time. | `list(string)` | `[]` | no |
 | <a name="input_iam_instance_profile_control_plane"></a> [iam\_instance\_profile\_control\_plane](#input\_iam\_instance\_profile\_control\_plane) | IAM instance profile to attach to the control plane instances to give AWS CCM the sufficient rights to execute. | `string` | `null` | no |
 | <a name="input_iam_instance_profile_worker"></a> [iam\_instance\_profile\_worker](#input\_iam\_instance\_profile\_worker) | IAM instance profile to attach to the worker instances to give AWS CCM the sufficient rights to execute. | `string` | `null` | no |
-| <a name="input_kubernetes_api_allowed_cidr"></a> [kubernetes\_api\_allowed\_cidr](#input\_kubernetes\_api\_allowed\_cidr) | The CIDR from which to allow to access the Kubernetes API | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_kubernetes_api_allowed_cidr"></a> [kubernetes\_api\_allowed\_cidr](#input\_kubernetes\_api\_allowed\_cidr) | The CIDR from which to allow to access the Kubernetes API | `string` | `""` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the Talos cluster, if not set, the K8s version shipped with the selected Talos version will be used. Check https://www.talos.dev/latest/introduction/support-matrix/. For example '1.29.3'. | `string` | `""` | no |
 | <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Metadata to attach to the instances. | `map(string)` | <pre>{<br/>  "http_endpoint": "enabled",<br/>  "http_put_response_hop_limit": 1,<br/>  "http_tokens": "optional"<br/>}</pre> | no |
 | <a name="input_pod_cidr"></a> [pod\_cidr](#input\_pod\_cidr) | The CIDR to use for Pods. Only required in case allocate\_node\_cidrs is set to 'true'. Otherwise, simply configure it inside Cilium's Helm values. | `string` | `"100.64.0.0/14"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region in which to create the Talos Linux cluster. | `string` | n/a | yes |
 | <a name="input_service_cidr"></a> [service\_cidr](#input\_service\_cidr) | The CIDR to use for services. | `string` | `"100.68.0.0/16"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The set of tags to place on the cluster. | `map(string)` | n/a | yes |
-| <a name="input_talos_api_allowed_cidr"></a> [talos\_api\_allowed\_cidr](#input\_talos\_api\_allowed\_cidr) | The CIDR from which to allow to access the Talos API | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_talos_api_allowed_cidr"></a> [talos\_api\_allowed\_cidr](#input\_talos\_api\_allowed\_cidr) | The CIDR from which to allow to access the Talos API | `string` | `""` | no |
 | <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | Talos version to use for the cluster, if not set, the newest Talos version. Check https://github.com/siderolabs/talos/releases for available releases. | `string` | `"v1.10.4"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The IPv4 CIDR block for the VPC. | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC where to place the VMs. | `string` | n/a | yes |

--- a/example/01-vpc.tf
+++ b/example/01-vpc.tf
@@ -4,11 +4,17 @@ resource "random_id" "cluster" {
   byte_length = 4
 }
 
-module "vpc" {
-  source = "git::https://github.com/isovalent/terraform-aws-vpc.git?ref=v1.11"
+# Used for ingress SG restrictions
+data "external" "public_ip" {
+  program = ["sh", "-c", "curl -s https://api.ipify.org?format=json"]
+}
 
-  cidr   = var.vpc_cidr
-  name   = "${var.cluster_name}-${random_id.cluster.dec}"
-  region = var.region
-  tags   = local.tags
+module "vpc" {
+  source = "git::https://github.com/isovalent/terraform-aws-vpc.git?ref=v1.12"
+
+  cidr                = var.vpc_cidr
+  name                = "${var.cluster_name}-${random_id.cluster.dec}"
+  access_ip_addresses = ["${data.external.public_ip.result.ip}/32"]
+  region              = var.region
+  tags                = local.tags
 }

--- a/example/02-talos.tf
+++ b/example/02-talos.tf
@@ -15,6 +15,8 @@ module "talos" {
   allocate_node_cidrs            = var.allocate_node_cidrs
   disable_kube_proxy             = var.disable_kube_proxy
   disable_containerd_nri_plugins = var.disable_containerd_nri_plugins
+  # Limit which source IP is able to access ingress port 6443 and 50000 (configured on the SG):
+  external_source_cidrs = ["${data.external.public_ip.result.ip}/32"]
   # For single-node cluster support:
   allow_workload_on_cp_nodes = var.allow_workload_on_cp_nodes
   controlplane_count         = var.controlplane_count

--- a/example/README.md
+++ b/example/README.md
@@ -102,6 +102,7 @@ aws-delete-vpc -cluster-name <Name of your cluster>
 
 | Name | Version |
 |------|---------|
+| <a name="provider_external"></a> [external](#provider\_external) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.7 |
 
 ### Modules
@@ -111,13 +112,14 @@ aws-delete-vpc -cluster-name <Name of your cluster>
 | <a name="module_cilium"></a> [cilium](#module\_cilium) | git::https://github.com/isovalent/terraform-k8s-cilium.git | v1.6.6 |
 | <a name="module_talos"></a> [talos](#module\_talos) | ../ | n/a |
 | <a name="module_tetragon"></a> [tetragon](#module\_tetragon) | git::https://github.com/isovalent/terraform-k8s-tetragon.git | v0.6.1 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/isovalent/terraform-aws-vpc.git | v1.11 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/isovalent/terraform-aws-vpc.git | v1.12 |
 
 ### Resources
 
 | Name | Type |
 |------|------|
 | [random_id.cluster](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [external_external.public_ip](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ### Inputs
 

--- a/test/conformance/00-providers.tf
+++ b/test/conformance/00-providers.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.100" # https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/434
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.5"
+      version = "~> 3.7"
     }
   }
 }

--- a/test/conformance/01-vpc.tf
+++ b/test/conformance/01-vpc.tf
@@ -1,11 +1,20 @@
+// Create the VPC.
+
 resource "random_id" "cluster" {
   byte_length = 4
 }
 
+# Used for ingress SG restrictions
+data "external" "public_ip" {
+  program = ["sh", "-c", "curl -s https://api.ipify.org?format=json"]
+}
+
 module "vpc" {
-  source = "git::https://github.com/isovalent/terraform-aws-vpc.git?ref=v1.7"
-  cidr   = var.vpc_cidr
-  name   = "${var.cluster_name}-${random_id.cluster.dec}"
-  region = var.region
-  tags   = local.tags
+  source = "git::https://github.com/isovalent/terraform-aws-vpc.git?ref=v1.12"
+
+  cidr                = var.vpc_cidr
+  name                = "${var.cluster_name}-${random_id.cluster.dec}"
+  access_ip_addresses = ["${data.external.public_ip.result.ip}/32"]
+  region              = var.region
+  tags                = local.tags
 }

--- a/test/conformance/02-talos.tf
+++ b/test/conformance/02-talos.tf
@@ -11,6 +11,8 @@ module "talos" {
   workers_count              = 1
   controlplane_count         = 1
   allow_workload_on_cp_nodes = true
+  # Limit which source IP is able to access ingress port 6443 and 50000 (configured on the SG):
+  external_source_cidrs = ["${data.external.public_ip.result.ip}/32"]
 
   // VPC needs to be created in advance via https://github.com/isovalent/terraform-aws-vpc
   vpc_id             = module.vpc.id

--- a/test/conformance/Makefile
+++ b/test/conformance/Makefile
@@ -38,9 +38,9 @@ destroy:
 init:
 	@if [ ! -f .timestamp ]; then\
 		if [ "$$(uname)" == "Darwin" ]; then\
-			out=$$(date -u -v+3d '+%Y-%m-%d') && echo -n "$$out" > .timestamp;\
+			out=$$(date -u -v+1d '+%Y-%m-%d') && echo -n "$$out" > .timestamp;\
 		else\
-			out=$$(date -u -d '+3 days' '+%Y-%m-%d') && echo -n "$$out" > .timestamp;\
+			out=$$(date -u -d '+1 days' '+%Y-%m-%d') && echo -n "$$out" > .timestamp;\
 		fi;\
 	fi
 	terraform init --upgrade


### PR DESCRIPTION
**BREAKING CHANGE**

So far, we've set `0.0.0.0/0` as default for the allowed ingress source IP CIDR(s) to access the Talos and Kubernetes APIs (on the security groups). This behavior is now changed in the sense that you must explicitly set `var.external_source_cidrs` to `0.0.0.0/0` to continue to use the old logic. If you don't do that, you won't be able to access the Talos and Kubernetes APIs from outside the VPC.

Especially for production, use something like the following code snippet to limit the source IP CIDR range to your specific public IP:
```
data "external" "public_ip" {
  program = ["sh", "-c", "curl -s https://api.ipify.org?format=json"]
}
```

... and then set `external_source_cidrs = ["${data.external.public_ip.result.ip}/32"]`.