### PR TITLE
chore(deps): bump Talos/Cilium versions and improve CI setup

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,48 +1,87 @@
-name: Terraform docs and formatting
+name: Terraform
+
 on:
-  pull_request: {}
-  push:
+  pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
-  formatting:
+  find-changed-dirs:
     runs-on: ubuntu-24.04
+    outputs:
+      dirs: ${{ steps.set-matrix.outputs.dirs }}
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: terraform fmt
-        uses: dflook/terraform-fmt-check@59168426e242f665bf7b70644d706224e665056a
-        with:
-          path: .
-      - name: terraform fmt
-        uses: dflook/terraform-fmt-check@59168426e242f665bf7b70644d706224e665056a
-        with:
-          path: example
-  docs:
-    needs: formatting
+          fetch-depth: 0
+
+      - name: Extract unique directories
+        id: set-matrix
+        run: |
+          merge_base=$(git merge-base origin/main HEAD)
+          dirs=$(git diff --name-only "$merge_base" HEAD -- '*.tf' | xargs -I{} dirname {} | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          echo "dirs=$dirs" >> $GITHUB_OUTPUT
+
+  terraform:
+    needs: find-changed-dirs
+    if: ${{ needs.find-changed-dirs.outputs.dirs != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: ${{ fromJson(needs.find-changed-dirs.outputs.dirs) }}
     runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ${{ matrix.folder }}
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - name: Render terraform docs inside the README.md and push changes back to PR branch
-        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c
+          ref: ${{ github.event.pull_request.head.ref || github.sha }}
+          fetch-depth: 0
+
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
-          working-dir: .
-          output-file: README.md
-          output-method: inject
-          output-format: markdown table
-          indention: 3
-          git-push: "true"
-      - name: Render terraform docs inside the README.md and push changes back to PR branch
-        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c
-        with:
-          working-dir: example/
-          output-file: README.md
-          output-method: inject
-          output-format: markdown table
-          indention: 3
-          git-push: "true"
+          terraform_version: 1.14.8
+
+      - name: Terraform Fmt
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Create Timestamp File
+        run: touch .timestamp
+
+      - name: Terraform Validate
+        run: terraform validate
+
+  final_status_check:
+    runs-on: ubuntu-24.04
+    needs: terraform
+    if: always()
+    name: Consolidated Status
+    steps:
+      - name: Check matrix job results
+        env:
+          TF_RESULT: ${{ needs.terraform.result }}
+        run: |
+          echo "Overall result of terraform job: $TF_RESULT"
+
+          if [ "$TF_RESULT" == "failure" ]; then
+            echo "One or more matrix jobs failed. Failing this consolidated check."
+            exit 1
+          elif [ "$TF_RESULT" == "cancelled" ]; then
+            echo "One or more matrix jobs were cancelled. Failing this consolidated check."
+            exit 1
+          elif [ "$TF_RESULT" == "skipped" ]; then
+            echo "The matrix job was skipped. This consolidated check will pass, but verify if this is desired behavior."
+            exit 0
+          else
+            echo "All matrix jobs passed successfully."
+            exit 0
+          fi

--- a/00-variables.tf
+++ b/00-variables.tf
@@ -88,7 +88,7 @@ variable "allow_workload_on_cp_nodes" {
 }
 
 variable "talos_version" {
-  default     = "v1.11.2"
+  default     = "v1.12.6"
   description = "Talos version to use for the cluster, if not set, the newest Talos version. Check https://github.com/siderolabs/talos/releases for available releases."
   type        = string
   validation {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module "talos" {
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.7 |
@@ -54,7 +54,7 @@ module "talos" {
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
@@ -64,7 +64,7 @@ module "talos" {
 ### Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_cluster_sg"></a> [cluster\_sg](#module\_cluster\_sg) | terraform-aws-modules/security-group/aws | ~> 5.3 |
 | <a name="module_nlb_sg"></a> [nlb\_sg](#module\_nlb\_sg) | terraform-aws-modules/security-group/aws | ~> 5.3 |
 | <a name="module_talos_control_plane_nodes"></a> [talos\_control\_plane\_nodes](#module\_talos\_control\_plane\_nodes) | terraform-aws-modules/ec2-instance/aws | ~> 6.0 |
@@ -73,7 +73,7 @@ module "talos" {
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_policy.control_plane_ccm_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.worker_ccm_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_lb.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
@@ -104,7 +104,7 @@ module "talos" {
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_admission_plugins"></a> [admission\_plugins](#input\_admission\_plugins) | List of admission plugins to enable | `string` | `"MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ServiceAccount"` | no |
 | <a name="input_allocate_node_cidrs"></a> [allocate\_node\_cidrs](#input\_allocate\_node\_cidrs) | Whether to assign PodCIDRs to Node resources or not. Only needed in case Cilium runs in 'kubernetes' IPAM mode. | `bool` | `true` | no |
 | <a name="input_allow_workload_on_cp_nodes"></a> [allow\_workload\_on\_cp\_nodes](#input\_allow\_workload\_on\_cp\_nodes) | Allow workloads on CP nodes or not. Allowing it means Talos Linux default taints are removed from CP nodes which is typically required for single-node clusters. More details here: https://www.talos.dev/v1.5/talos-guides/howto/workers-on-controlplane/ | `bool` | `false` | no |
@@ -128,7 +128,7 @@ module "talos" {
 | <a name="input_region"></a> [region](#input\_region) | The region in which to create the Talos Linux cluster. | `string` | n/a | yes |
 | <a name="input_service_cidr"></a> [service\_cidr](#input\_service\_cidr) | The CIDR to use for services. | `string` | `"100.68.0.0/16"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The set of tags to place on the cluster. | `map(string)` | n/a | yes |
-| <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | Talos version to use for the cluster, if not set, the newest Talos version. Check https://github.com/siderolabs/talos/releases for available releases. | `string` | `"v1.11.2"` | no |
+| <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | Talos version to use for the cluster, if not set, the newest Talos version. Check https://github.com/siderolabs/talos/releases for available releases. | `string` | `"v1.12.6"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The IPv4 CIDR block for the VPC. | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC where to place the VMs. | `string` | n/a | yes |
 | <a name="input_worker_groups"></a> [worker\_groups](#input\_worker\_groups) | List of node worker node groups to create | <pre>list(object({<br/>    name               = string<br/>    instance_type      = optional(string, "m5.large")<br/>    config_patch_files = optional(list(string), [])<br/>    tags               = optional(map(string), {})<br/>  }))</pre> | <pre>[<br/>  {<br/>    "name": "default"<br/>  }<br/>]</pre> | no |
@@ -137,7 +137,7 @@ module "talos" {
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of cluster |
 | <a name="output_elb_dns_name"></a> [elb\_dns\_name](#output\_elb\_dns\_name) | [DEPRECATED: Use lb\_dns\_name instead] Public load balancer DNS name. |
 | <a name="output_kubeconfig"></a> [kubeconfig](#output\_kubeconfig) | Kubeconfig content |

--- a/example/00-variables.tf
+++ b/example/00-variables.tf
@@ -162,7 +162,7 @@ variable "cilium_helm_chart" {
 }
 
 variable "cilium_helm_version" {
-  default     = "1.17.4"
+  default     = "1.19.3"
   description = "The version of the used Helm chart. Check https://github.com/cilium/cilium/releases to see available versions."
   type        = string
 }

--- a/example/README.md
+++ b/example/README.md
@@ -94,21 +94,21 @@ aws-delete-vpc -cluster-name <Name of your cluster>
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.7 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_external"></a> [external](#provider\_external) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.7 |
+| ---- | ------- |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 
 ### Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_cilium"></a> [cilium](#module\_cilium) | git::https://github.com/isovalent/terraform-k8s-cilium.git | v1.6.8 |
 | <a name="module_talos"></a> [talos](#module\_talos) | ../ | n/a |
 | <a name="module_tetragon"></a> [tetragon](#module\_tetragon) | git::https://github.com/isovalent/terraform-k8s-tetragon.git | v0.6.1 |
@@ -117,20 +117,20 @@ aws-delete-vpc -cluster-name <Name of your cluster>
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [random_id.cluster](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [external_external.public_ip](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_allocate_node_cidrs"></a> [allocate\_node\_cidrs](#input\_allocate\_node\_cidrs) | Whether to assign PodCIDRs to Node resources or not. Only needed in case Cilium runs in 'kubernetes' IPAM mode. | `bool` | `false` | no |
 | <a name="input_allow_workload_on_cp_nodes"></a> [allow\_workload\_on\_cp\_nodes](#input\_allow\_workload\_on\_cp\_nodes) | Allow workloads on CP nodes or not. Allowing it means Talos Linux default taints are removed from CP nodes which is typically required for single-node clusters. More details here: https://www.talos.dev/v1.5/talos-guides/howto/workers-on-controlplane/ | `bool` | `false` | no |
 | <a name="input_cilium_helm_chart"></a> [cilium\_helm\_chart](#input\_cilium\_helm\_chart) | The name of the Helm chart to be used. The naming depends on the Helm repo naming on the local machine. | `string` | `"cilium/cilium"` | no |
 | <a name="input_cilium_helm_values_file_path"></a> [cilium\_helm\_values\_file\_path](#input\_cilium\_helm\_values\_file\_path) | Cilium values file | `string` | `"03-cilium-values.yaml"` | no |
 | <a name="input_cilium_helm_values_override_file_path"></a> [cilium\_helm\_values\_override\_file\_path](#input\_cilium\_helm\_values\_override\_file\_path) | Override Cilium values file | `string` | `""` | no |
-| <a name="input_cilium_helm_version"></a> [cilium\_helm\_version](#input\_cilium\_helm\_version) | The version of the used Helm chart. Check https://github.com/cilium/cilium/releases to see available versions. | `string` | `"1.17.4"` | no |
+| <a name="input_cilium_helm_version"></a> [cilium\_helm\_version](#input\_cilium\_helm\_version) | The version of the used Helm chart. Check https://github.com/cilium/cilium/releases to see available versions. | `string` | `"1.19.3"` | no |
 | <a name="input_cilium_namespace"></a> [cilium\_namespace](#input\_cilium\_namespace) | The namespace in which to install Cilium. | `string` | `"kube-system"` | no |
 | <a name="input_cluster_architecture"></a> [cluster\_architecture](#input\_cluster\_architecture) | Cluster architecture. Choose 'arm64' or 'amd64'. If you choose 'arm64', ensure to also override the control\_plane.instance\_type and worker\_groups.instance\_type with an ARM64-based instance type like 'm7g.large'. | `string` | `"amd64"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The (Cilium) ID of the cluster. Must be unique for Cilium ClusterMesh and between 0-255. | `number` | `"1"` | no |
@@ -163,7 +163,7 @@ aws-delete-vpc -cluster-name <Name of your cluster>
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cilium_namespace"></a> [cilium\_namespace](#output\_cilium\_namespace) | n/a |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Cluster name |
 | <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | Public NLB DNS name. |


### PR DESCRIPTION
- Bump module default Talos version from v1.11.2 to v1.12.6
- Bump example Talos version from v1.10.7 to v1.13.0-rc.0
- Bump example Cilium default from 1.17.4 to 1.19.3 and tfvars from 1.18.7 to 1.19.3
- ci: overhaul terraform workflow