### PR TITLE
ci: update GitHub Actions for Node.js 24

### DIFF
--- a/.github/workflows/conformance-pr.yml
+++ b/.github/workflows/conformance-pr.yml
@@ -35,17 +35,17 @@ jobs:
             ingress-controller: false
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure AWS credentials from shared services account
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: arn:aws:iam::478566851380:role/TalosConformanceCI
           aws-region: us-east-2
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: GH Runner Public IP
         id: public_ip
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ !success() }}
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cilium-sysdumps-${{ github.run_id }}-${{ github.run_number }}
           path: ./test/conformance/cilium-sysdump-*.zip

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -86,17 +86,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Configure AWS credentials from shared services account
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: arn:aws:iam::478566851380:role/TalosConformanceCI
           aws-region: us-east-2
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: GH Runner Public IP
         id: public_ip
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ !success() }}
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cilium-sysdumps-${{ github.run_id }}-${{ github.run_number }}
           path: ./test/conformance/cilium-sysdump-*.zip


### PR DESCRIPTION
## What changed

- Upgrade `actions/checkout` to `v7.0.1`.
- Upgrade `aws-actions/configure-aws-credentials` to `v6.2.3`.
- Upgrade `hashicorp/setup-terraform` to `v4.0.1`.
- Upgrade `actions/upload-artifact` to `v7.0.1`.

## Files changed

- `.github/workflows/conformance-pr.yml`
- `.github/workflows/conformance.yml`

## Why

This work addresses [isovalent/roadmap#3310](https://github.com/isovalent/roadmap/issues/3310).

GitHub Actions runners are moving to Node.js 24 and dropping older JavaScript runtimes. Updating these actions keeps the affected workflows operational after that transition.

External actions remain pinned to immutable commit SHAs so a mutable tag cannot change the workflow implementation without review.
